### PR TITLE
Rename project from bw_payroll

### DIFF
--- a/.ruby-gemset
+++ b/.ruby-gemset
@@ -1,1 +1,1 @@
-bw_payroll
+payroll

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <title>BwPayroll</title>
+  <title>Payroll</title>
   <%= javascript_include_tag 'http://www.google.com/jsapi' %>
   <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true %>
   <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -13,7 +13,7 @@ require "sprockets/railtie"
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
-module BwPayroll
+module Payroll
   class Application < Rails::Application
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers

--- a/config/database.yml
+++ b/config/database.yml
@@ -23,13 +23,13 @@ default: &default
 
 development:
   <<: *default
-  database: bw_payroll_development
+  database: payroll_development
 
   # The specified database role being used to connect to postgres.
   # To create additional roles in postgres see `$ createuser --help`.
   # When left blank, postgres will use the default role. This is
   # the same name as the operating system user that initialized the database.
-  #username: bw_payroll
+  #username: payroll
 
   # The password associated with the postgres role (username).
   #password:
@@ -57,7 +57,7 @@ development:
 # Do not set this db to the same as development or production.
 test: &test
   <<: *default
-  database: bw_payroll_test
+  database: payroll_test
 
 # As with config/secrets.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is
@@ -80,9 +80,9 @@ test: &test
 #
 production:
   <<: *default
-  database: bw_payroll_production
-  username: bw_payroll
-  password: <%= ENV['BW_PAYROLL_DATABASE_PASSWORD'] %>
+  database: payroll_production
+  username: payroll
+  password: <%= ENV['PAYROLL_DATABASE_PASSWORD'] %>
 
 cucumber:
   <<: *test

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,3 +1,3 @@
 # Be sure to restart your server when you modify this file.
 
-Rails.application.config.session_store :cookie_store, key: '_bw_payroll_session'
+Rails.application.config.session_store :cookie_store, key: '_payroll_session'


### PR DESCRIPTION
Rename project from bw_payroll to payroll
This includes changing the names of the databases and the gemset, so be sure to
- re-create the database (`rake db:drop` and `rake db:setup`)
- move your gemset from bw_payroll to payroll
