### PR TITLE
Improve look of forms on wide screens

### DIFF
--- a/app/views/charts/_form.html.haml
+++ b/app/views/charts/_form.html.haml
@@ -1,38 +1,37 @@
 %h3 Filter Graph Results
-.col-lg-6
+.col-lg-9
   .well.bs-component
     = form_tag({}, {method: :get}) do
       %fieldset
         .form-group
-          .col-lg-2.control-label Employment Status:
-          .col-lg-10
+          .control-label Employment Status:
+          %span.checkbox-inline
             = label_tag do
               = check_box_tag 'employment[current]', 1, params[:employment].try(:[], :current)
               Current
+          %span.checkbox-inline
             = label_tag do
               = check_box_tag 'employment[past]', 1, params[:employment].try(:[], :past)
               Past
+          %span.checkbox-inline
             = label_tag do
               = check_box_tag 'employment[future]', 1, params[:employment].try(:[], :future)
               Future
         -# .form-group
-          -# .col-lg-2.control-label Billable Status:
-          -# .col-lg-10
-            -# = label_tag do
-              -# = check_box_tag 'billable[true]', 1, params[:billable].try(:[], :true)
-              -# Billable
-            -# = label_tag do
-              -# = check_box_tag 'billable[false]', 1, params[:billable].try(:[], :false)
-              -# Support
+          -# .control-label Billable Status:
+          -# = label_tag do
+            -# = check_box_tag 'billable[true]', 1, params[:billable].try(:[], :true)
+            -# Billable
+          -# = label_tag do
+            -# = check_box_tag 'billable[false]', 1, params[:billable].try(:[], :false)
+            -# Support
         -# .form-group
-          -# .col-lg-2.control-label Owner:
-          -# .col-lg-10
-            -# = label_tag do
-              -# = check_box_tag 'owner[false]', 1, params[:owner].try(:[], :false)
-              -# Non-Owner
-            -# = label_tag do
-              -# = check_box_tag 'owner[true]', 1, params[:owner].try(:[], :true)
-              -# Owner
+          -# .control-label Owner:
+          -# = label_tag do
+            -# = check_box_tag 'owner[false]', 1, params[:owner].try(:[], :false)
+            -# Non-Owner
+          -# = label_tag do
+            -# = check_box_tag 'owner[true]', 1, params[:owner].try(:[], :true)
+            -# Owner
         .form-group
-          .col-lg-10.col-lg-offset-2
-            = submit_tag 'Filter', class: 'btn btn-primary'
+          = submit_tag 'Filter', class: 'btn btn-primary'

--- a/app/views/devise/invitations/edit.html.haml
+++ b/app/views/devise/invitations/edit.html.haml
@@ -1,18 +1,16 @@
 %h2= t 'devise.invitations.edit.header'
 = devise_error_messages!
-.col-lg-6
+.col-lg-9
   .well.bs-component
     = form_for resource, :as => resource_name, :url => invitation_path(resource_name), :html => { :method => :put } do |f|
       %fieldset
         = f.hidden_field :invitation_token
         .form-group
-          = f.label :password, class: 'col-lg-2 control-label'
-          .col-lg-10
-            = f.password_field :password, class: 'form-control'
+          = f.label :password, class: 'control-label'
+          = f.password_field :password, class: 'form-control'
         .form-group
-          = f.label :password_confirmation, class: 'col-lg-2 control-label'
-          .col-lg-10
-            = f.password_field :password_confirmation, class: 'form-control'
+          = f.label :password_confirmation, class: 'control-label'
+          = f.password_field :password_confirmation, class: 'form-control'
         .form-group
           .col-lg-10.col-lg-offset-2
             = f.submit t("devise.invitations.edit.submit_button"), class: 'btn btn-primary'

--- a/app/views/devise/invitations/new.html.haml
+++ b/app/views/devise/invitations/new.html.haml
@@ -1,15 +1,13 @@
 %h2= t "devise.invitations.new.header"
 = devise_error_messages!
-.col-lg-6
+.col-lg-9
   .well.bs-component
     = form_for resource, :as => resource_name, :url => invitation_path(resource_name), :html => {:method => :post} do |f|
       %fieldset
         - resource.class.invite_key_fields.each do |field|
           .form-group
-            = f.label field, class: 'col-lg-2 control-label'
-            .col-lg-10
-              = f.text_field field, autofocus: true, class: 'form-control'
+            = f.label field, class: 'control-label'
+            = f.text_field field, autofocus: true, class: 'form-control'
         .form-group
-          .col-lg-10.col-lg-offset-2
-            = f.submit t("devise.invitations.new.submit_button"), class: 'btn btn-primary'
+          = f.submit t("devise.invitations.new.submit_button"), class: 'btn btn-primary'
 = link_to "Back", :back

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -1,32 +1,27 @@
 %h2 Edit account
 - unless devise_error_messages! == ""
   .form_error.alert.alert-danger= devise_error_messages!
-.col-lg-6
+.col-lg-9
   .well.bs-component
     = form_for(resource, as: resource_name, url: user_registration_path(resource), html: { method: :patch, class: 'form-horizontal' }) do |f|
       %fieldset
-        .form-group
-          = f.label :email, class: 'col-lg-2 control-label'
-          .col-lg-10
-            = f.email_field :email, autofocus: true, class: 'form-control'
+        .form-group.col-lg-12
+          = f.label :email, class: 'control-label'
+          = f.email_field :email, autofocus: true, class: 'form-control'
         - if devise_mapping.confirmable? && resource.pending_reconfirmation?
           %div
             Currently waiting confirmation for: #{resource.unconfirmed_email}
-        .form-group
-          = f.label :password, class: 'col-lg-2 control-label'
-          .col-lg-10
-            %span.help-block Leave blank if you don't want to change it.
-            = f.password_field :password, autocomplete: "off", class: 'form-control'
-        .form-group
-          = f.label :password_confirmation, class: 'col-lg-2 control-label'
-          .col-lg-10
-            = f.password_field :password_confirmation, autocomplete: "off", class: 'form-control'
-        .form-group
-          = f.label :current_password, class: 'col-lg-2 control-label'
-          .col-lg-10
-            %span.help-block We need your current password to confirm your changes.
-            = f.password_field :current_password, autocomplete: "off", class: 'form-control'
-        .form-group
-          .col-lg-10.col-lg-offset-2
-            = f.submit "Update", class: 'btn btn-primary'
-= link_to "Back", :back
+        .form-group.col-lg-12
+          = f.label :password, class: 'control-label'
+          %span.help-block Leave blank if you don't want to change it.
+          = f.password_field :password, autocomplete: "off", class: 'form-control'
+        .form-group.col-lg-12
+          = f.label :password_confirmation, class: 'control-label'
+          = f.password_field :password_confirmation, autocomplete: "off", class: 'form-control'
+        .form-group.col-lg-12
+          = f.label :current_password, class: 'control-label'
+          %span.help-block We need your current password to confirm your changes.
+          = f.password_field :current_password, autocomplete: "off", class: 'form-control'
+        .form-group.col-lg-12
+          = f.submit "Update", class: 'btn btn-primary'
+  = link_to "Back", :back

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -1,21 +1,18 @@
 %h2 Log in
-.col-lg-6
+.col-lg-9
   .well.bs-component
     = form_for(resource, as: resource_name, url: session_path(resource_name), html: {class: 'form-horizontal'}) do |f|
       %fieldset
-        .form-group
-          = f.label :email, class: 'col-lg-2 control-label'
-          .col-lg-10
-            = f.email_field :email, autofocus: true, class: 'form-control'
-        .form-group
-          = f.label :password, class: 'col-lg-2 control-label'
-          .col-lg-10
-            = f.password_field :password, autocomplete: "off", class: 'form-control'
-            .checkbox
-              %label
-                = f.check_box :remember_me
-                = f.label :remember_me
-        .form-group
-          .col-lg-10.col-lg-offset-2
-            = f.submit "Log in", class: 'btn btn-primary'
-= render "devise/shared/links"
+        .form-group.col-lg-12
+          = f.label :email, class: 'control-label'
+          = f.email_field :email, autofocus: true, class: 'form-control'
+        .form-group.col-lg-12
+          = f.label :password, class: 'control-label'
+          = f.password_field :password, autocomplete: "off", class: 'form-control'
+          .checkbox
+            %label
+              = f.check_box :remember_me
+              = f.label :remember_me
+        .form-group.col-lg-12
+          = f.submit "Log in", class: 'btn btn-primary'
+  = render "devise/shared/links"

--- a/app/views/employees/_form.html.haml
+++ b/app/views/employees/_form.html.haml
@@ -4,45 +4,36 @@
     %ul
       - errors.each do |msg|
         %li= msg
-.col-lg-6
+.col-lg-9
   .well.bs-component
     = form_for(employee, html: { class: 'form-horizontal' }) do |f|
       %fieldset
-        .form-group
-          = f.label :first_name, class: 'col-lg-2 control-label'
-          .col-lg-10
-            = f.text_field :first_name, autofocus: true, class: 'form-control', required: true
-        .form-group
-          = f.label :last_name, class: 'col-lg-2 control-label'
-          .col-lg-10
-            = f.text_field :last_name, class: 'form-control', required: true
-        .form-group
-          = f.label :start_date, class: 'col-lg-2 control-label'
-          .col-lg-10
-            = f.date_field :start_date, class: 'form-control', required: true
-        .form-group
-          = f.label :end_date, class: 'col-lg-2 control-label'
-          .col-lg-10
-            = f.date_field :end_date, class: 'form-control'
-        .form-group
-          = f.label :direct_experience, 'Direct experience (months)', class: 'col-lg-2 control-label'
-          .col-lg-10
-            = f.number_field :direct_experience, class: 'form-control'
-        .form-group
-          = f.label :indirect_experience, 'Indirect experience (months)', class: 'col-lg-2 control-label'
-          .col-lg-10
-            = f.number_field :indirect_experience, class: 'form-control'
-        .form-group
-          = f.label :starting_salary, 'Starting salary annual amount', class: 'col-lg-2 control-label'
-          .col-lg-10
-            .input-group
-              %span.input-group-addon $
-              = f.number_field :starting_salary, class: 'form-control', required: true
-        .form-group
-          .col-lg-10
-            = f.check_box :billable
-            = f.label :billable, class: 'col-lg-2 control-label'
-        .form-group
-          .col-lg-10.col-lg-offset-2
-            = f.submit 'Save', class: 'btn btn-primary'
-            = link_to 'Cancel', :back, class: 'btn btn-default'
+        .form-group.col-lg-12
+          = f.label :first_name, class: 'control-label'
+          = f.text_field :first_name, autofocus: true, class: 'form-control', required: true
+        .form-group.col-lg-12
+          = f.label :last_name, class: 'control-label'
+          = f.text_field :last_name, class: 'form-control', required: true
+        .form-group.col-lg-12
+          = f.label :start_date, class: 'control-label'
+          = f.date_field :start_date, class: 'form-control', required: true
+        .form-group.col-lg-12
+          = f.label :end_date, class: 'control-label'
+          = f.date_field :end_date, class: 'form-control'
+        .form-group.col-lg-12
+          = f.label :direct_experience, 'Direct experience (months)', class: 'control-label'
+          = f.number_field :direct_experience, class: 'form-control'
+        .form-group.col-lg-12
+          = f.label :indirect_experience, 'Indirect experience (months)', class: 'control-label'
+          = f.number_field :indirect_experience, class: 'form-control'
+        .form-group.col-lg-12
+          = f.label :starting_salary, 'Starting salary annual amount', class: 'control-label'
+          .input-group
+            %span.input-group-addon $
+            = f.number_field :starting_salary, class: 'form-control', required: true
+        .form-group.col-lg-12
+          = f.check_box :billable
+          = f.label :billable, class: 'control-label'
+        .form-group.col-lg-12
+          = f.submit 'Save', class: 'btn btn-primary'
+          = link_to 'Cancel', :back, class: 'btn btn-default'

--- a/app/views/salaries/new.html.haml
+++ b/app/views/salaries/new.html.haml
@@ -5,21 +5,18 @@
     %ul
       - @salary.errors.full_messages.each do |msg|
         %li= msg
-.col-lg-6
+.col-lg-9
   .well.bs-component
     = form_for(@salary, url: employee_salaries_path(@salary.employee), html: { class: 'form-horizontal' }) do |f|
       %fieldset
-        .form-group
-          = f.label :start_date, class: 'col-lg-2 control-label'
-          .col-lg-10
-            = f.date_field :start_date, class: 'form-control', required: true, autofocus: true
-        .form-group
-          = f.label :annual_amount, class: 'col-lg-2 control-label'
-          .col-lg-10
-            .input-group
-              %span.input-group-addon $
-              = f.number_field :annual_amount, class: 'form-control', required: true, value: @salary.employee.salary_on(Date.today)
-        .form-group
-          .col-lg-10.col-lg-offset-2
-            = f.submit 'Save', class: 'btn btn-primary'
-            = link_to 'Cancel', employee_path(@salary.employee), class: 'btn btn-default'
+        .form-group.col-lg-12
+          = f.label :start_date, class: 'control-label'
+          = f.date_field :start_date, class: 'form-control', required: true, autofocus: true
+        .form-group.col-lg-12
+          = f.label :annual_amount, class: 'control-label'
+          .input-group
+            %span.input-group-addon $
+            = f.number_field :annual_amount, class: 'form-control', required: true, value: @salary.employee.salary_on(Date.today)
+        .form-group.col-lg-12
+          = f.submit 'Save', class: 'btn btn-primary'
+          = link_to 'Cancel', employee_path(@salary.employee), class: 'btn btn-default'


### PR DESCRIPTION
Previously, we used Bootstrap's `col-lg-6` to limit size of forms on large screens, but this was unnecessary, since no pages have enough content that they want multiple columns. 
Also, form contents used columns to separate labels and form fields into columns, but this looked cramped and bad. Now labels go above fields.