### PR TITLE
Highlight current location in nav bar

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -15,3 +15,5 @@
 //= require turbolinks
 //= require bootstrap-sprockets
 //= require_tree .
+
+

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -17,7 +17,17 @@
 @import 'bootstrap-sprockets';
 @import 'bootstrap';
 
+$color: #18bc9c;
 
 .navbar-default .navbar-nav > li > a.active_link {
-	color: #18bc9c;
+	color: $color;
+}
+
+li {
+	.add > a.active_menu {
+		color: $color;
+	}
+	:nth-child(n) > a.active_menu {
+		color: $color;
+	}
 }

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -16,3 +16,8 @@
 
 @import 'bootstrap-sprockets';
 @import 'bootstrap';
+
+
+.navbar-default .navbar-nav > li > a.active_link {
+	color: #18bc9c;
+}

--- a/app/views/layouts/_accounts_dropdown.html.haml
+++ b/app/views/layouts/_accounts_dropdown.html.haml
@@ -3,7 +3,7 @@
   %b.caret
 %ul.dropdown-menu
   - Account.all.each do |account|
-    %li= link_to account.name, account_path(account)
+    %li= link_to account.name, account_path(account), class: ("active_menu" if current_page?(account_path(account)))
   %li.divider
-  %li= link_to 'Add account', new_account_path
-  %li= link_to 'Upload balances CSV', upload_balances_form_accounts_path
+  %li= link_to 'Add account', new_account_path, class: ("active_menu" if current_page?(new_account_path))
+  %li= link_to 'Upload balances CSV', upload_balances_form_accounts_path, class: ("active_menu" if current_page?(upload_balances_form_accounts_path))

--- a/app/views/layouts/_employees_dropdown.html.haml
+++ b/app/views/layouts/_employees_dropdown.html.haml
@@ -2,12 +2,14 @@
   Employees
   %b.caret
 %ul.dropdown-menu
-  %li= link_to 'Add employee', new_employee_path
+  %li.add= link_to 'Add employee', new_employee_path, class: ("active_menu" if current_page?(new_employee_path))
   %li.divider
   %li.dropdown-header Current Employees
   - Employee.current.each do |e|
-    %li= link_to e.first_name, employee_path(e)
+    %li= link_to e.first_name, employee_path(e), class: ("active_menu" if current_page?(employee_path(e)))
   %li.divider
   %li.dropdown-header Inactive Employees
   - Employee.non_current.each do |e|
-    %li= link_to e.first_name, employee_path(e)
+    %li= link_to e.first_name, employee_path(e), class: ("active_menu" if current_page?(employee_path(e)))
+
+

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -20,16 +20,16 @@
             .navbar-collapse.collapse.navbar-responsive-collapse
               - if user_signed_in?
                 %ul.nav.navbar-nav
-                  %li= link_to 'Home', root_path
-                  %li= link_to 'Balances', balances_path
-                  %li= link_to 'Salaries', salaries_path
-                  %li= link_to 'Experience', experience_path
+                  %li= link_to 'Home', root_path, class: ("active_link" if current_page?(root_path))
+                  %li= link_to 'Balances', balances_path, class: ("active_link" if current_page?(balances_path))
+                  %li= link_to 'Salaries', salaries_path, class: ("active_link" if current_page?(salaries_path))
+                  %li= link_to 'Experience', experience_path, class: ("active_link" if current_page?(experience_path))
                 %ul.nav.navbar-nav.navbar-right
                   %li.dropdown
                     = render "layouts/employees_dropdown"
                   %li.dropdown
                     = render "layouts/accounts_dropdown"
-                  %li= link_to 'Users', users_path
+                  %li= link_to 'Users', users_path, class: ("active_link" if current_page?(users_path))
                   %li.dropdown
                     %a.dropdown-toggle#charts{"aria-expanded" => "false", "data-toggle" => "dropdown", :href => "#"}
                       = current_user.email


### PR DESCRIPTION
Use different CSS style to show the user which nav bar selection is currently selected.

For instance, when current page is History chart, that option in the Charts dropdown in the nav bar should be a different color.

Note: If we are using a bootstrap theme, this may simply require setting a class on the HTML element of the selected menu choice.