### PR TITLE
Replace rails_12factor with Production configuration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,10 +55,6 @@ group :test do
   gem 'shoulda-matchers'                # Collection of testing matchers
 end
 
-group :production do
-  gem 'rails_12factor' # Run Rails the 12factor way
-end
-
 group :doc do
   gem 'sdoc' # rdoc generator
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -252,9 +252,6 @@ GEM
       ruby-graphviz (~> 1.2)
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
-    rails_12factor (0.0.3)
-      rails_serve_static_assets
-      rails_stdout_logging
     rails_best_practices (1.19.4)
       activesupport
       code_analyzer (>= 0.4.8)
@@ -263,8 +260,6 @@ GEM
       json
       require_all (~> 2.0)
       ruby-progressbar
-    rails_serve_static_assets (0.0.5)
-    rails_stdout_logging (0.0.5)
     railties (6.0.2)
       actionpack (= 6.0.2)
       activesupport (= 6.0.2)
@@ -392,7 +387,6 @@ DEPENDENCIES
   rails (= 6.0.2)
   rails-controller-testing
   rails-erd
-  rails_12factor
   rails_best_practices
   rake
   rspec-rails (= 4.0.0.beta3)
@@ -412,4 +406,4 @@ RUBY VERSION
    ruby 2.6.3p62
 
 BUNDLED WITH
-   2.0.2
+   2.1.0

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -22,8 +22,11 @@ Rails.application.configure do
   # consider using a caching reverse proxy like nginx, varnish or squid.
   # config.action_dispatch.rack_cache = true
 
-  # Disable Rails's static asset server (Apache or nginx will already do this).
-  config.serve_static_files = true
+  # Disable serving static files from the `/public` folder by default since
+  # Apache or NGINX already handles this.
+  # Replaces rails_serve_static_assets via rails_12factor gem
+  # https://github.com/heroku/rails_12factor#migrating-to-rails-5
+  config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
   # Compress JavaScripts and CSS.
   config.assets.js_compressor = :uglifier
@@ -51,8 +54,13 @@ Rails.application.configure do
   # Prepend all log lines with the following tags.
   # config.log_tags = [ :subdomain, :uuid ]
 
-  # Use a different logger for distributed setups.
-  # config.logger = ActiveSupport::TaggedLogging.new(SyslogLogger.new)
+  # Replaces rails_stdout_logging via rails_12factor gem
+  # https://github.com/heroku/rails_12factor#migrating-to-rails-5
+  if ENV["RAILS_LOG_TO_STDOUT"].present?
+    logger           = ActiveSupport::Logger.new(STDOUT)
+    logger.formatter = config.log_formatter
+    config.logger = ActiveSupport::TaggedLogging.new(logger)
+  end
 
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store


### PR DESCRIPTION
`rails_stdout_logging` gem, installed by `rails_12factor`, has a deprecation
warning due to inclusion of `LoggerSilence`. While checking to see if
there were reports about this already on the gem, found a suggestion
that `rails_12factor` features were already put into Rails 5 and
production configuration could achieve the same ends without requiring
the gem.

https://github.com/heroku/rails_12factor#migrating-to-rails-5

This commit makes the relevant changes to production configuration and
removes the gem per the readme for `rails_12factor` cited in the conf
file.

### Verify Heroku Env Configuration
From the link above:

> Make sure to add both the RAILS_SERVE_STATIC_FILES and RAILS_LOG_TO_STDOUT ENV vars and set them to true. (This is done for you on Heroku)

Fixes #55 