### PR TITLE
Add headless ability to feature tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,6 +54,7 @@ group :test do
   gem 'cucumber-rails', require: false  # Automated acceptance tests
   gem 'database_cleaner'                # Strategies for cleaning databases
   gem 'factory_bot_rails'               # Setup Ruby objects as test data
+  gem 'headless'                        # Headless browser runner for Cucumber tests
   gem 'launchy'
   gem 'rails-controller-testing'        # Allows us to use assigns in testing
   gem 'selenium-webdriver'              # Automated tests of websites

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -185,6 +185,7 @@ GEM
       haml (>= 4.0.6, < 6.0)
       html2haml (>= 1.0.1)
       railties (>= 5.1)
+    headless (2.3.1)
     html2haml (2.2.0)
       erubis (~> 2.7.0)
       haml (>= 4.0, < 6)
@@ -430,6 +431,7 @@ DEPENDENCIES
   google_visualr!
   haml
   haml-rails
+  headless
   immigrant
   jbuilder
   jquery-rails

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Simple internal application to visualize payroll and inform salary decisions at 
 
 We're using [google_visualr gem](https://github.com/winston/google_visualr) for graphing. [Documentation](http://googlevisualr.herokuapp.com/)
 
-To get this up and running:
+## Initial Setup
   1. clone it
   1. Make sure rvm, yarn, and the correct ruby are installed
   1. `bundle install`
@@ -17,13 +17,29 @@ To get this up and running:
   1. `rails s`
   1. visit localhost:3000
 
-To run the tests:
+## Tests
+To run the entire test suite:
   1. `rake`
 
-To deploy:
+To run test suite with headless feature tests:
+  1. *Prerequisite - once: Install `xvfb` via `sudo apt-get install xvfb`
+  2. `HEADLESS=true rake`
+
+To run specs only:
+  1. `rake spec`
+
+To run cucumber features only:
+  1. `rake cucumber`
+
+To run headless cucumber features only:
+  1. Ensure you have `xvfb` installed (see above)
+  2. `HEADLESS=true rake cucumber`
+
+## Deploy
   1. once: `git remote add heroku https://git.heroku.com/bendyworks-payroll.git`
   1. `bin/deploy.sh`
 
+## Add a User in Console
 To create a new user:
   1. From the project directory, start the console with `rails c`.
   1. `User.create(email: 'your@email.com', password: 'yourpassword')`
@@ -33,7 +49,7 @@ To change your password in the console:
   1. `u = User.find_by_email('your@email.com')`
   1. `u.update password: 'newpassword'`
 
-Using React Components
+## Using React Components
   1. React components live inside app/javascript/components
   1. Components can be rendered inside the views with:
   ~~~

--- a/features/support/headless.rb
+++ b/features/support/headless.rb
@@ -1,0 +1,23 @@
+# Allows Cucumber tests to run as headless, in coordination with 'headless' gem
+#
+# @note = in order for headless to work, you must `sudo apt install xvfb`, because 'xvfb' helps run headless tests
+# @ref = https://github.com/leonid-shevtsov/headless
+# @ref = https://sermoa.wordpress.com/2011/07/02/cucumber-running-headless-selenium-with-jenkins-the-easy-way/
+#
+# To run headless cucumber tests, just pass the HEADLESS var via command line like this:
+#   $ HEADLESS=true cucumber              or,
+#   $ HEADLESS=true rake cucumber         or,
+#   $ HEADLESS=true bundle exec cucumber
+#
+# Conversely, to run cucumber tests without headless (you see the browser window appear and run through each test),
+# simply do not pass the HEADLESS variable beforehand
+if ENV['HEADLESS'] == 'true'
+	require 'headless'
+
+	headless = Headless.new
+	headless.start
+
+	at_exit do
+		headless.destroy
+	end
+end


### PR DESCRIPTION
## Purpose
Adds the ability to run Cucumber feature tests "headless-ly".

## How to run headless feature tests
1. Bundle install
2. Once: download `xvfb` package via `sudo apt-get install xvfb`, which helps run headless part
3. `HEADLESS=true rake`, or specifically for features: `HEADLESS=true rake cucumber`

## Changes
- Add new gem 'headless' to test group
- Add new file `features/support/headless.rb`
    - Include details on how to run headless tests from command line 
- Update README to include how to run feature tests 
- Update README to have more clear section titles